### PR TITLE
Add possibility to download report as pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Run the Docker image using `docker run -p 8501:8501 arundeep78/website-broken-li
 3. Click the "Scan" button
 4. Wait for the scan to complete
 5. View the results in the web interface
+6. Click the "Download report as PDF" button to download the report as a PDF file
 
 ## Features
 
@@ -27,7 +28,7 @@ Run the Docker image using `docker run -p 8501:8501 arundeep78/website-broken-li
 - Download broken links table for internal, external or complete set
 - Supports max requests rate limit
 - Supports ignoring TLS certificate checks
-
+- Download the report as a PDF file
 
 ## Limitations - what may come next
 

--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@ import  utils
 import fragments
 import time
 from humanize import naturaldelta
+from utils import generate_pdf_report, get_pdf_download_link
 
 #set streamlit UI to wide screen mode
 st.set_page_config(layout="wide")
@@ -122,6 +123,10 @@ if submitted:
         with col2:
             # Add a link for the download of whole results dataframe
             st.markdown(utils.get_table_download_link(results), unsafe_allow_html=True,)
+            # Add a button for downloading the report as a PDF
+            if st.button("Download report as PDF"):
+                generate_pdf_report(results)
+                st.markdown(get_pdf_download_link(), unsafe_allow_html=True)
      
         if not 'error' in results.columns:
          
@@ -182,7 +187,3 @@ if submitted:
             # sub_heading += f" | {count_unique_externals_error}{'' if count_unique_externals == 0 else '/'+ str(count_unique_externals)}"
             # st.subheader(sub_heading)
             st.write(external_links)
-
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit==1.33.0
 humanize==4.9.0
+reportlab==3.6.12


### PR DESCRIPTION
Fixes #2

Add functionality to download report as PDF with overview and details tables.

* **app/utils.py**
  - Import `reportlab` library for PDF generation.
  - Add `generate_pdf_report` function to create a PDF report from a dataframe.
  - Add `get_pdf_download_link` function to generate a download link for the PDF file.

* **app/app.py**
  - Import `generate_pdf_report` and `get_pdf_download_link` functions.
  - Add a button for downloading the report as a PDF.
  - Call `generate_pdf_report` function when the PDF download button is clicked.
  - Add a markdown link to download the generated PDF report.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/arundeep78/website-broken-links/pull/3?shareId=afa75cf9-1161-46c9-baa6-f7c91fe0721c).